### PR TITLE
Rewritten alternative stroke evaluator

### DIFF
--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/core/PathExtensions.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/core/PathExtensions.kt
@@ -45,6 +45,29 @@ fun Path.approximateEvenly(pointsCount: Int): ApproximatedPath {
     )
 }
 
+fun Path.approximateEquidistant(distance:Float): ApproximatedPath {
+    val pathMeasure = PathMeasure()
+    pathMeasure.setPath(this, false)
+
+    val pathLength = pathMeasure.length
+
+    // less than "distance" pixels at the end are discarded due to rounding
+    val nIntervals = (pathLength/distance).toInt()
+
+    // divide path into nIntervals segments, store all starting points of all segments and
+    // the end point of the last segment.
+    val points = (0 until  nIntervals+1).map {
+        val fraction = it.toFloat() / nIntervals.toFloat() * pathLength
+        val point = pathMeasure.pointAt(min(fraction, pathLength))
+        PathPointF(fraction, point.x, point.y)
+    }
+
+    return ApproximatedPath(
+        length = pathLength,
+        points = points
+    )
+}
+
 fun List<PointF>.center(): PointF {
     return PointF(
         sumOf { it.x.toDouble() / size }.toFloat(),
@@ -97,6 +120,13 @@ fun Path.getStats(interpolationPoints:Int): PathStats {
     )
 }
 
+fun Path.getStats(distance:Float): PathStats {
+    val approximatedPath = approximateEquidistant(distance)
+    return PathStats(
+        length = approximatedPath.length,
+        evenlyApproximated = approximatedPath.points.map { PointF(it.x, it.y) }
+    )
+}
 
 private const val INTERPOLATION_POINTS = 1 + 195
 

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/core/PathExtensions.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/core/PathExtensions.kt
@@ -3,6 +3,7 @@ package ua.syt0r.kanji.core
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.PathMeasure
+import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.pow
 import kotlin.math.sqrt
@@ -45,20 +46,20 @@ fun Path.approximateEvenly(pointsCount: Int): ApproximatedPath {
     )
 }
 
-fun Path.approximateEquidistant(distance:Float): ApproximatedPath {
+fun Path.approximateEquidistant(distance: Float): ApproximatedPath {
     val pathMeasure = PathMeasure()
     pathMeasure.setPath(this, false)
 
     val pathLength = pathMeasure.length
 
     // less than "distance" pixels at the end are discarded due to rounding
-    val nIntervals = (pathLength/distance).toInt()
+    val nIntervals = max(1, (pathLength / distance).toInt())
 
     // divide path into nIntervals segments, store all starting points of all segments and
     // the end point of the last segment.
     val points = (0 until  nIntervals+1).map {
         val fraction = it.toFloat() / nIntervals.toFloat() * pathLength
-        val point = pathMeasure.pointAt(min(fraction, pathLength))
+        val point = pathMeasure.getPosition(min(fraction, pathLength))
         PathPointF(fraction, point.x, point.y)
     }
 
@@ -120,7 +121,7 @@ fun Path.getStats(interpolationPoints:Int): PathStats {
     )
 }
 
-fun Path.getStats(distance:Float): PathStats {
+fun Path.getStats(distance: Float): PathStats {
     val approximatedPath = approximateEquidistant(distance)
     return PathStats(
         length = approximatedPath.length,

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/core/stroke_evaluator/AltKanjiStrokeEvaluator.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/core/stroke_evaluator/AltKanjiStrokeEvaluator.kt
@@ -1,10 +1,12 @@
 package ua.syt0r.kanji.core.stroke_evaluator
 
 import androidx.compose.ui.graphics.Path
+import ua.syt0r.kanji.core.PointF
 import ua.syt0r.kanji.core.euclDistance
 import ua.syt0r.kanji.core.getStats
 import ua.syt0r.kanji.core.logger.Logger
 import ua.syt0r.kanji.presentation.common.ui.kanji.KanjiSize
+import kotlin.math.abs
 import kotlin.math.atan2
 import kotlin.math.cos
 import kotlin.math.max
@@ -16,11 +18,71 @@ import kotlin.math.sqrt
 class AltKanjiStrokeEvaluator : KanjiStrokeEvaluator {
 
     companion object {
+        // difficulty. lower is easier.
+        private const val DIFFICULTY = 1.0f
+
         private const val SIMILARITY_ERROR_THRESHOLD = 10f
-        private const val MAX_INTERPOLATION_POINTS = 22
-        private const val MIN_INTERPOLATION_POINTS = 5
-        private const val SEGMENT_SCALE = 5
-        private const val DEAD_BAND = 22f
+
+        // divide path into segments of this length
+        private const val SEGMENT_LENGTH = 5f
+
+        // dead band below which there is no error contribution
+        private const val POSITIONAL_DEAD_BAND = 44f / DIFFICULTY
+
+        // dead band (in degrees) below which there is no error contribution
+        private const val DIRECTIONAL_DEAD_BAND = 5f / DIFFICULTY
+
+        // skipping path segments of either path to get a better match still incurs some error
+        // see function gapCost()
+        private const val GAP_OPENING = 5f
+        private const val GAP_EXTENSION = 5f
+
+        // max positional error in number of dead bands
+        private const val MAX_POSITIONAL_ERROR = 6f / DIFFICULTY
+
+        // max directional error in degrees
+        private const val MAX_DIRECTIONAL_ERROR = 30f / DIFFICULTY
+
+        // scaling constant to make balancing with gap costs easier
+        private const val ERROR_SCALE = 20f
+    }
+
+    private data class Vector2d(val a: Double, val b: Double) : Comparable<Vector2d> {
+        operator fun plus(other: Vector2d) = Vector2d(a + other.a, b + other.b)
+
+        // adding equal amounts of scalar to both components
+        operator fun plus(scalar: Double): Vector2d {
+            if ((a == 0.0) && (b == 0.0)) {
+                val ab = sqrt(0.5 * (scalar.pow(2.0)))
+                return Vector2d(ab, ab)
+            }
+
+            if (a == 0.0) return Vector2d(0.0, b + scalar)
+
+            // the following handles all other cases including b==0.0
+            val newLength = this.length() + scalar
+            val denominator = sqrt((b / a).pow(2.0) + 1)
+
+            return Vector2d(newLength / denominator, newLength * (b / a) / denominator)
+        }
+
+        operator fun div(scalar: Double):Vector2d = Vector2d(this.a/scalar,this.b/scalar)
+
+        // there's no order on complex numbers or 2D vectors. We do it a bit wonky here.
+        // correct? no! sufficient? yes!
+        override operator fun compareTo(other: Vector2d): Int {
+            // both components strictly larger -> this larger than other
+            if ((a > other.a) && (b > other.b)) return 1
+
+            // both components strictly smaller -> this smaller than other
+            if ((a < other.a) && (b < other.b)) return -1
+
+            // here be dragons
+            return if (this.length() > other.length()) 1
+            else -1
+        }
+
+        fun length(): Double = sqrt(a.pow(2.0) + b.pow(2.0))
     }
 
     override fun areStrokesSimilar(
@@ -30,65 +92,141 @@ class AltKanjiStrokeEvaluator : KanjiStrokeEvaluator {
         return error <= SIMILARITY_ERROR_THRESHOLD
     }
 
-    private fun getError(first: Path, second: Path): Float {
-        // divide into equal segment based on path length. Don't know whether this is strictly
-        // necessary. Might be a bit expensive. Maybe drop it and use fixed number of segments.
-        var firstStats = first.getStats(MAX_INTERPOLATION_POINTS)
-        val pointsCount = min(
-            MAX_INTERPOLATION_POINTS,
-            max(MIN_INTERPOLATION_POINTS, firstStats.length.toInt() / SEGMENT_SCALE)
-        )
-        firstStats = first.getStats(pointsCount)
-        val secondStats = second.getStats(pointsCount)
+    private fun gapCost(length: Int): Double =
+        GAP_OPENING + GAP_EXTENSION * (length.toDouble().pow(2.0))
 
-        // absolute position error based on RMSE with dead band. Deviations within the dead band
-        // contribute nothing to the sum. Deviations larger than dead band are squared. Dead band
-        // is KanjiSize/n. Larger values for n are harder, lower values are easier.
-        val pointsDistanceSum = firstStats.evenlyApproximated.zip(secondStats.evenlyApproximated)
-            .sumOf {
-                max(0f, euclDistance(it.first, it.second) - KanjiSize / DEAD_BAND).toDouble()
-                    .pow(2.0)
+    private fun <T> minWhence(values: List<Vector2d>, offsets: List<T>): Pair<Vector2d, T> {
+        assert(values.size == offsets.size)
+        var minimum = values[0]
+        var offset = offsets[0]
+
+        (1 until values.size).forEach { position ->
+            if (values[position] < minimum) {
+                minimum = values[position]
+                offset = offsets[position]
             }
-
-        // normalize then take square root
-        val pointsDistanceError = sqrt(pointsDistanceSum / pointsCount)
-
-        var directionError = 0.0
-
-        // for all path segments of the first path, compute the angle between it and the x-axis
-        for (i in 0 until pointsCount - 1) {
-            val firstDirection = atan2(
-                (firstStats.evenlyApproximated[i + 1].y - firstStats.evenlyApproximated[i].y).toDouble(),
-                (firstStats.evenlyApproximated[i + 1].x - firstStats.evenlyApproximated[i].x).toDouble()
-            )
-
-            // since atan2 wraps around at 180 degrees, we avoid nasty conditional blocks by rotating
-            // the corresponding segment of the second path by the angle computed for the first path
-            // in order to keep the differences small and avoid any edge cases. That is, the angle
-            // computed for the rotated line segment is exactly the deviation to the first line but
-            // within the interval [-PI,PI] which is the interval atan2 returns.
-            val tx =
-                (secondStats.evenlyApproximated[i + 1].x - secondStats.evenlyApproximated[i].x) * cos(
-                    -firstDirection
-                ) - (secondStats.evenlyApproximated[i + 1].y - secondStats.evenlyApproximated[i].y) * sin(
-                    -firstDirection
-                )
-            val ty =
-                (secondStats.evenlyApproximated[i + 1].y - secondStats.evenlyApproximated[i].y) * cos(
-                    -firstDirection
-                ) + (secondStats.evenlyApproximated[i + 1].x - secondStats.evenlyApproximated[i].x) * sin(
-                    -firstDirection
-                )
-
-            // Multiply by a constant and square so that larger deviations are worse.
-            directionError += (5 * atan2(ty, tx)).pow(2.0)
         }
 
-        // normalize and take square root.
-        directionError = sqrt(directionError / pointsCount)
+        return Pair(minimum, offset)
+    }
 
-        val cumulativeError = pointsDistanceError.toFloat() + directionError.toFloat()
-        Logger.d("error[$cumulativeError] distanceErr[$pointsDistanceError] directionErr[$directionError]")
-        return cumulativeError
+    private fun getError(first: Path, second: Path): Float {
+        val firstStats = first.getStats(SEGMENT_LENGTH)
+        val secondStats = second.getStats(SEGMENT_LENGTH)
+        val distanceMatrix: Array<Array<Vector2d>> = Array(firstStats.evenlyApproximated.size) {
+            Array(secondStats.evenlyApproximated.size) { Vector2d(0.0, 0.0) }
+        }
+
+        for (column in 1 until secondStats.evenlyApproximated.size) distanceMatrix[0][column] =
+            Vector2d(0.0, 0.0) + gapCost(column)
+
+        for (row in 1 until firstStats.evenlyApproximated.size) distanceMatrix[row][0] =
+            Vector2d(0.0, 0.0) + gapCost(row)
+
+        for (row in 1 until firstStats.evenlyApproximated.size) {
+            for (column in 1 until secondStats.evenlyApproximated.size) {
+                var rowMin = distanceMatrix[row][0]
+                var rowMinAt = 0
+                var columnMin = distanceMatrix[0][column]
+                var columnMinAt = 0
+
+                (1 until column).forEach { k ->
+                    if (distanceMatrix[row][k] < rowMin) {
+                        rowMin = distanceMatrix[row][k]
+                        rowMinAt = k
+                    }
+                }
+
+                (1 until row).forEach { k ->
+                    if (distanceMatrix[k][column] < columnMin) {
+                        columnMin = distanceMatrix[k][column]
+                        columnMinAt = k
+                    }
+                }
+
+                rowMin += gapCost(column - rowMinAt)
+                columnMin += gapCost(row - columnMinAt)
+
+                distanceMatrix[row][column] = minOf(
+                    rowMin, columnMin, distanceMatrix[row - 1][column - 1] + Vector2d(
+                        (distanceError(
+                            firstStats.evenlyApproximated[row - 1],
+                            secondStats.evenlyApproximated[column - 1]
+                        ) + distanceError(
+                            firstStats.evenlyApproximated[row],
+                            secondStats.evenlyApproximated[column]
+                        )) / 2.0, directionalError(
+                            firstStats.evenlyApproximated[row - 1],
+                            firstStats.evenlyApproximated[row],
+                            secondStats.evenlyApproximated[column - 1],
+                            secondStats.evenlyApproximated[column]
+                        )
+                    )
+                )
+            }
+        }
+
+        var row = firstStats.evenlyApproximated.size - 1
+        var column = secondStats.evenlyApproximated.size - 1
+        var pathLength = 0
+
+        while ((row > 0) && (column > 0)) {
+            val offset = minWhence(
+                listOf(
+                    distanceMatrix[row - 1][column - 1],
+                    distanceMatrix[row][column - 1],
+                    distanceMatrix[row - 1][column]
+                ), listOf(Pair(-1, -1), Pair(0, -1), Pair(-1, 0))
+            ).second
+
+            row += offset.first
+            column += offset.second
+            pathLength++
+        }
+
+        pathLength += row + column
+        if (firstStats.evenlyApproximated.size < 10) pathLength++
+        if (firstStats.evenlyApproximated.size < 5) pathLength++
+
+        val error =
+            distanceMatrix[firstStats.evenlyApproximated.size - 1][secondStats.evenlyApproximated.size - 1] / pathLength.toDouble()
+        Logger.d("error[${error.length()}] distanceErr[${error.a}] directionErr[${error.b}]")
+        return error.length().toFloat()
+    }
+
+    private fun directionalError(
+        pointA1: PointF, pointA2: PointF, pointB1: PointF, pointB2: PointF
+    ): Double {
+        val firstDirection = atan2(
+            (pointA2.y - pointA1.y).toDouble(), (pointA2.x - pointA1.x).toDouble()
+        )
+
+        // since atan2 wraps around at 180 degrees, we avoid nasty conditional blocks by rotating
+        // the corresponding segment of the second path by the angle computed for the first path
+        // in order to keep the differences small and avoid any edge cases. That is, the angle
+        // computed for the rotated line segment is exactly the deviation to the first line but
+        // within the interval [-PI,PI] which is the interval atan2 returns.
+        val tx =
+            (pointB2.x - pointB1.x) * cos(-firstDirection) - (pointB2.y - pointB1.y) * sin(-firstDirection)
+        val ty =
+            (pointB2.y - pointB1.y) * cos(-firstDirection) + (pointB2.x - pointB1.x) * sin(-firstDirection)
+
+        // Normalize, cap and multiply by a constant
+        return ERROR_SCALE * min(
+            1.0,
+            max(
+                0.0,
+                abs(180f * atan2(ty, tx) / Math.PI) - DIRECTIONAL_DEAD_BAND
+            ) / MAX_DIRECTIONAL_ERROR
+        )
+    }
+
+    private fun distanceError(pointA: PointF, pointB: PointF): Double {
+        val error = (max(
+            0f, euclDistance(pointA, pointB) - KanjiSize / POSITIONAL_DEAD_BAND
+        ) / (MAX_POSITIONAL_ERROR * KanjiSize / POSITIONAL_DEAD_BAND)).toDouble().pow(2.5)
+
+        // cap and scale
+        return ERROR_SCALE * min(1.0, error)
     }
 }


### PR DESCRIPTION
Sorry to keep you waiting for so long. Was quite tricky.

I've completely rewritten the alternate stroke evaluator. The new algorithm is a heavily modified version (not much left of the original) of the Waterman-Smith-Beyer-algorithm for global DNA sequence alignment (implemented something similar several years ago). I changed the distance matrix calculation and adapted the algorithm to work with two dimensional and continuous error values instead of discrete character data.

The algorithm aligns two sequences of stroke segments by keeping track of distances between all segments. If some segment of either path does not match a segment of the other path gaps are introduced. These still incur some error value but this way the matching of later segments will self-synchronize and errors will not pile up. Thus, the situation you described with character 級 is not present anymore (within reason). Too many gaps in a row will add more and more error (quadratic).

I also relaxed the error evaluation a bit to make the algorithm more forgiving. Difficulty can be set through a constant but I think it's quite good now. Maybe a bit too easy but you convinced me that this is the better approach.

Also deleted and reforked the project to appease GIT a bit. Pull request only changes two files.