### PR TITLE
Add option to show kana reading during vocab writing.

### DIFF
--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/core/user_data/preferences/PracticePreferences.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/core/user_data/preferences/PracticePreferences.kt
@@ -84,4 +84,10 @@ class PracticePreferences(
         initialValue = { true }
     )
 
+    override val vocabWritingShowKanaReading: SuspendedProperty<Boolean> = createProperty(
+        type = BooleanSuspendedPropertyType,
+        key = "vocab_writing_show_kana_reading",
+        initialValue = { false }
+    )
+
 }

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/core/user_data/preferences/PreferencesContract.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/core/user_data/preferences/PreferencesContract.kt
@@ -74,6 +74,7 @@ interface PreferencesContract {
 
         val vocabFlashcardMeaningInFront: SuspendedProperty<Boolean>
         val vocabReadingPickerShowMeaning: SuspendedProperty<Boolean>
+        val vocabWritingShowKanaReading: SuspendedProperty<Boolean>
 
     }
 

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/common/resources/string/EnglishStrings.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/common/resources/string/EnglishStrings.kt
@@ -619,6 +619,9 @@ object EnglishVocabPracticeStrings : VocabPracticeStrings {
     override val translationInFrontConfigurationTitle: String = "Translation In Front"
     override val translationInFrontConfigurationMessage: String =
         "Show translation instead of word when flashcard is hidden"
+    override val writingKanaReadingConfigurationTitle: String = "Show Kana Readings"
+    override val writingKanaReadingConfigurationMessage: String =
+        "Show kana readings even before answer is entered"
     override val detailsButton: String = "Details"
 }
 

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/common/resources/string/JapaneseStrings.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/common/resources/string/JapaneseStrings.kt
@@ -596,6 +596,9 @@ object JapaneseVocabPracticeStrings : VocabPracticeStrings {
     override val translationInFrontConfigurationTitle: String = "表に翻訳を置く"
     override val translationInFrontConfigurationMessage: String =
         "フラッシュカードが隠れているときに単語の代わりに翻訳を表示する"
+    override val writingKanaReadingConfigurationTitle: String = "かなの読み方の表示"
+    override val writingKanaReadingConfigurationMessage: String =
+        "答えを入力する前でもかなの読み方を表示します"
     override val detailsButton: String = "詳細"
 }
 

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/common/resources/string/Strings.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/common/resources/string/Strings.kt
@@ -591,6 +591,9 @@ interface VocabPracticeStrings {
     val translationInFrontConfigurationTitle: String
     val translationInFrontConfigurationMessage: String
 
+    val writingKanaReadingConfigurationTitle: String
+    val writingKanaReadingConfigurationMessage: String
+
     val detailsButton: String
 
 }

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/VocabPracticeScreenContract.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/VocabPracticeScreenContract.kt
@@ -34,7 +34,8 @@ interface VocabPracticeScreenContract {
             val practiceType: ScreenVocabPracticeType,
             val cardsSelectorState: PracticeConfigurationCardsSelectorState,
             val flashcard: VocabPracticeConfiguration.Flashcard,
-            val readingPicker: VocabPracticeConfiguration.ReadingPicker
+            val readingPicker: VocabPracticeConfiguration.ReadingPicker,
+            val writing: VocabPracticeConfiguration.Writing
         ) : ScreenState
 
         data class Review(

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/VocabPracticeScreenUI.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/VocabPracticeScreenUI.kt
@@ -186,7 +186,13 @@ private fun ScreenConfiguration(
             }
 
             ScreenVocabPracticeType.Writing -> {
-
+                var showKanaReading by screenState.writing.showKanaReading
+                PracticeConfigurationOption(
+                    title = resolveString { vocabPractice.writingKanaReadingConfigurationTitle },
+                    subtitle = resolveString { vocabPractice.writingKanaReadingConfigurationMessage },
+                    checked = showKanaReading,
+                    onChange = { showKanaReading = it }
+                )
             }
         }
 

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/VocabPracticeViewModel.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/VocabPracticeViewModel.kt
@@ -62,6 +62,11 @@ class VocabPracticeViewModel(
                     showMeaning = mutableStateOf(
                         practicePreferences.vocabReadingPickerShowMeaning.get()
                     )
+                ),
+                writing = VocabPracticeConfiguration.Writing(
+                    showKanaReading = mutableStateOf(
+                        practicePreferences.vocabWritingShowKanaReading.get()
+                    )
                 )
             )
         }
@@ -77,6 +82,7 @@ class VocabPracticeViewModel(
                 newCardsOrder.set(configurationState.cardsSelectorState.newCardsOrder.value)
                 vocabReadingPickerShowMeaning.set(configurationState.readingPicker.showMeaning.value)
                 vocabFlashcardMeaningInFront.set(configurationState.flashcard.translationInFront.value)
+                vocabWritingShowKanaReading.set(configurationState.writing.showKanaReading.value)
             }
 
             practiceQueue.initialize(

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/data/VocabPracticeQueueData.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/data/VocabPracticeQueueData.kt
@@ -81,6 +81,7 @@ sealed interface VocabPracticeQueueItemDescriptor {
     data class Writing(
         override val cardId: Long,
         override val deckId: Long,
+        val showKanaReading: Boolean
     ) : VocabPracticeQueueItemDescriptor {
         override val practiceType: ScreenVocabPracticeType = ScreenVocabPracticeType.Writing
     }
@@ -148,7 +149,9 @@ sealed interface VocabPracticeItemData {
         val meaning: String,
         val summaryReading: FuriganaString,
         val writerData: List<Pair<String, CharacterWriterData?>>,
-        val vocabReference: InfoScreenData.Vocab
+        val vocabReference: InfoScreenData.Vocab,
+        val kanaReading: String,
+        val showKanaReading: Boolean
     ) : VocabPracticeItemData {
 
         override fun toReviewState(
@@ -173,7 +176,9 @@ sealed interface VocabPracticeItemData {
                     }
                 )
             },
-            vocabReference = vocabReference
+            vocabReference = vocabReference,
+            kanaReading = kanaReading,
+            showKanaReading = showKanaReading
         )
 
     }
@@ -226,6 +231,8 @@ sealed interface MutableVocabReviewState {
         override val charactersData: List<VocabCharacterWritingData>,
         override val meaning: String,
         override val vocabReference: InfoScreenData.Vocab,
+        override val kanaReading: String,
+        override val showKanaReading: Boolean
     ) : MutableVocabReviewState, VocabReviewState.Writing {
         override val asImmutable: VocabReviewState.Writing = this
         override val selected: MutableState<VocabCharacterWritingData> = mutableStateOf(

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/data/VocabPracticeScreenData.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/data/VocabPracticeScreenData.kt
@@ -46,6 +46,10 @@ sealed interface VocabPracticeConfiguration {
         val showMeaning: MutableState<Boolean>
     ) : VocabPracticeConfiguration
 
+    data class Writing(
+        val showKanaReading: MutableState<Boolean>
+    ) : VocabPracticeConfiguration
+
 }
 
 sealed interface VocabReviewState {
@@ -73,6 +77,8 @@ sealed interface VocabReviewState {
     interface Writing : VocabReviewState {
         val charactersData: List<VocabCharacterWritingData>
         val selected: MutableState<VocabCharacterWritingData>
+        val kanaReading: String
+        val showKanaReading: Boolean
     }
 
 }

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/ui/VocabPracticeWritingUI.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/ui/VocabPracticeWritingUI.kt
@@ -222,6 +222,14 @@ private fun Progress(
             },
         )
 
+        if (reviewState.showKanaReading) {
+            Text(
+                text = reviewState.kanaReading,
+                style = MaterialTheme.typography.bodyLarge,
+                textAlign = TextAlign.Center
+            )
+        }
+
         val lazyListState = rememberLazyListState()
         AutoscrollCharacterIndicatorRowLaunchedEffect(reviewState, lazyListState)
 

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/use_case/GetVocabPracticeQueueDataUseCase.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/use_case/GetVocabPracticeQueueDataUseCase.kt
@@ -79,7 +79,8 @@ class DefaultGetVocabPracticeQueueDataUseCase(
                     ScreenVocabPracticeType.Writing -> {
                         VocabPracticeQueueItemDescriptor.Writing(
                             cardId = wordId,
-                            deckId = deckId
+                            deckId = deckId,
+                            showKanaReading = configuratedState.writing.showKanaReading.value
                         )
                     }
                 }

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/use_case/GetVocabPracticeWritingDataUseCase.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/presentation/screen/main/screen/practice_vocab/use_case/GetVocabPracticeWritingDataUseCase.kt
@@ -75,7 +75,9 @@ class DefaultGetVocabPracticeWritingDataUseCase(
             meaning = card.meaning,
             summaryReading = summaryReading,
             writerData = writerData,
-            vocabReference = card.toInfoScreenData()
+            vocabReference = card.toInfoScreenData(),
+            showKanaReading = descriptor.showKanaReading,
+            kanaReading = card.kanaReading
         )
     }
 


### PR DESCRIPTION
Currently, when doing vocab writing practice, there's no way to distinguish two different words that have the same English meaning but different spelling/pronunciation. This PR adds a setting to display the kana reading to help figure out which word you're supposed to write.

This is similar to #222, but this PR shows the whole kana reading without indicating which kana belong to which kanji. My thinking is that this way ~~is way easier to implement~~ is better practice for situations where you've heard a word spoken out loud and need to write it down. (Even if the word doesn't have any kanji in it, you still have to _remember_ that it doesn't have any kanji in it.)

I don't actually know Japanese, so the strings I added in `JapaneseStrings.kt` came from an online translation app.

<img width="371" height="373" alt="image" src="https://github.com/user-attachments/assets/cef4f3e0-d9b3-4c8b-b153-9eec696edc82" />

<img width="521" height="418" alt="image" src="https://github.com/user-attachments/assets/ba6647c0-d89d-4882-9fc5-4a428e55fd43" />
