### PR TITLE
Fixing performance issue introduced in 2.2.0

### DIFF
--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/core/srs/SrsManager.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/core/srs/SrsManager.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
@@ -29,6 +30,8 @@ abstract class SrsManager<ItemType, PracticeType, Deck>(
 
     private var cache: SrsDecksData<Deck, PracticeType>? = null
 
+    private var resetTime: LocalTime = LocalTime(0,0)
+
     private val srsCardComparator: Comparator<SrsCardData> =
         compareByDescending { (_, srsCardData) -> srsCardData?.lastReview }
 
@@ -45,6 +48,7 @@ abstract class SrsManager<ItemType, PracticeType, Deck>(
             .onEach {
                 cache = null
                 _dataChangeFlow.emit(Unit)
+                resetTime = appPreferences.dailyResetTime.get()
             }
             .launchIn(coroutineScope)
     }
@@ -136,9 +140,8 @@ abstract class SrsManager<ItemType, PracticeType, Deck>(
         ).also { cache = it }
     }
 
-    protected suspend fun Instant.toSrsDate(): LocalDate {
+    protected fun Instant.toSrsDate(): LocalDate {
         val localDateTime = toLocalDateTime(TimeZone.currentSystemDefault())
-        val resetTime = appPreferences.dailyResetTime.get()
         return if (localDateTime.time < resetTime) {
             localDateTime.date.minus(1, DateTimeUnit.DAY)
         } else {
@@ -146,7 +149,7 @@ abstract class SrsManager<ItemType, PracticeType, Deck>(
         }
     }
 
-    protected suspend fun getSrsStatus(srsCard: SrsCard?): SrsItemStatus {
+    protected fun getSrsStatus(srsCard: SrsCard?): SrsItemStatus {
         val expectedReviewTime = srsCard?.run { lastReview?.plus(interval) }
         val expectedReviewDate = expectedReviewTime?.toSrsDate()
         val currentDate = timeUtils.now().toSrsDate()
@@ -157,7 +160,7 @@ abstract class SrsManager<ItemType, PracticeType, Deck>(
         }
     }
 
-    protected suspend fun PracticeTypeDeckData<ItemType>.toProgress(
+    protected fun PracticeTypeDeckData<ItemType>.toProgress(
         deckLimit: DeckLimit,
         practiceType: PracticeType,
         today: LocalDate

--- a/core/src/commonMain/kotlin/ua/syt0r/kanji/core/srs/SrsManager.kt
+++ b/core/src/commonMain/kotlin/ua/syt0r/kanji/core/srs/SrsManager.kt
@@ -30,7 +30,7 @@ abstract class SrsManager<ItemType, PracticeType, Deck>(
 
     private var cache: SrsDecksData<Deck, PracticeType>? = null
 
-    private var resetTime: LocalTime = LocalTime(0,0)
+    private var cachedResetTime: LocalTime? = null
 
     private val srsCardComparator: Comparator<SrsCardData> =
         compareByDescending { (_, srsCardData) -> srsCardData?.lastReview }
@@ -46,9 +46,9 @@ abstract class SrsManager<ItemType, PracticeType, Deck>(
             appPreferences.dailyResetTime.onModified
         )
             .onEach {
+                cachedResetTime = null
                 cache = null
                 _dataChangeFlow.emit(Unit)
-                resetTime = appPreferences.dailyResetTime.get()
             }
             .launchIn(coroutineScope)
     }
@@ -78,6 +78,7 @@ abstract class SrsManager<ItemType, PracticeType, Deck>(
     }
 
     protected suspend fun getDecksInternal(): SrsDecksData<Deck, PracticeType> {
+        cachedResetTime = cachedResetTime ?: appPreferences.dailyResetTime.get()
         cache?.let { return it }
 
         val deckDescriptors: List<SrsDeckDescriptor<ItemType, PracticeType>>
@@ -141,6 +142,7 @@ abstract class SrsManager<ItemType, PracticeType, Deck>(
     }
 
     protected fun Instant.toSrsDate(): LocalDate {
+        val resetTime = cachedResetTime ?: LocalTime(0,0)
         val localDateTime = toLocalDateTime(TimeZone.currentSystemDefault())
         return if (localDateTime.time < resetTime) {
             localDateTime.date.minus(1, DateTimeUnit.DAY)


### PR DESCRIPTION
After updating the app to 2.2.0, I noticed the same behavior reported in #297.


I cloned the repository and reverted commits one by one until I found, that the performance problems were introduced in fa05ead.
While reviewing the new additions, I found that the  `getSrsStatus` function gets called multiple times while the loading screen happens. Every time the function gets called, the `resetTime` variable gets fetched from the AppPreferences. The repeated fetching of this variable seems to cause performance related issues on large datasets.

**What I did**:
I decided on caching this value within the `SrsManager`, and updating the cached value whenever the original gets changed.